### PR TITLE
Only register the mail if specified in the config.

### DIFF
--- a/src/WordPress/Components/Mail.php
+++ b/src/WordPress/Components/Mail.php
@@ -27,7 +27,9 @@ final class Mail extends Component
      */
     public function register()
     {
-        $this->action->add('phpmailer_init', [$this, 'mail']);
+        if (config('mail.host') && config('mail.username') && config('mail.password')) {
+            $this->action->add('phpmailer_init', [$this, 'mail']);
+        }
     }
 
     /**


### PR DESCRIPTION
We don't want to force `phpmailer_init` if not needed or the user wants to specify it.
