### PR TITLE
Login header URL links to site/wordpress

### DIFF
--- a/src/WordPress/Components/Login.php
+++ b/src/WordPress/Components/Login.php
@@ -51,7 +51,7 @@ final class Login extends Component
      */
     public function loginHeaderUrl()
     {
-        return get_site_url();
+        return get_bloginfo('url');
     }
 
     /**


### PR DESCRIPTION
The URL on the logo header on login page should link to the site URL not the backend URL with the /wordpress. Now it results in a 404 page.
