### PR TITLE
Fixed bug where the public folder wasn't found when not 'public'

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -172,6 +172,10 @@ final class Application extends Container
      */
     public function getPublicPath(): string
     {
+        if (is_null($this->publicPath)) {
+            return $this->basePath.DIRECTORY_SEPARATOR.env('WP_PUBLIC_PATH', 'public');
+        }
+
         return $this->publicPath;
     }
 


### PR DESCRIPTION
We had an issue using Wordplate with a host that only allowed uploading to a 'www'-folder, instead of a 'public'-folder.
This PR enables the user to choose the PublicPath based on an ENV-variable, with 'public' as a default.