### PR TITLE
Read Mix manifest from children theme

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -92,7 +92,7 @@ if (!function_exists('mix')) {
         }
 
         if (!$manifest) {
-            if (!file_exists($manifestPath = template_path($manifestDirectory.'/mix-manifest.json'))) {
+            if (!file_exists($manifestPath = stylesheet_path($manifestDirectory.'/mix-manifest.json'))) {
                 throw new Exception('The Mix manifest does not exist.');
             }
 


### PR DESCRIPTION
...if child theme exists, otherwise from regular theme (as before this commit).

Issue: If a child theme was being used, this helper tried to look for the Mix manifest in the parent theme.