### PR TITLE
Delay plugin activation

### DIFF
--- a/src/PluginLoader.php
+++ b/src/PluginLoader.php
@@ -85,7 +85,6 @@ final class PluginLoader
 
         foreach (array_keys($this->getPlugins()) as $plugin) {
             // include all plugins, whether they are activated or not
-            // TODO check which plugins are activated and only include them (to possible save run time)
             require_once WPMU_PLUGIN_DIR.'/'.$plugin;
         }
 
@@ -95,7 +94,6 @@ final class PluginLoader
         add_action('after_setup_theme', function () use ($plugin) {
             foreach (array_keys($this->getPlugins()) as $plugin) {
                 // activate all plugins whether they've already been activated before
-                // TODO check which plugins aren't already activated first (to possible save run time)
                 do_action('activate_'.$plugin);
             }
         });

--- a/src/PluginLoader.php
+++ b/src/PluginLoader.php
@@ -87,7 +87,7 @@ final class PluginLoader
             require_once WPMU_PLUGIN_DIR.'/'.$plugin;
         }
 
-        add_action('after_setup_theme', function () use ($plugin) {
+        add_action('after_setup_theme', function () {
             foreach (array_keys($this->getPlugins()) as $plugin) {
                 do_action('activate_'.$plugin);
             }

--- a/src/PluginLoader.php
+++ b/src/PluginLoader.php
@@ -84,16 +84,11 @@ final class PluginLoader
         }
 
         foreach (array_keys($this->getPlugins()) as $plugin) {
-            // include all plugins, whether they are activated or not
             require_once WPMU_PLUGIN_DIR.'/'.$plugin;
         }
 
-        // 'after_setup_theme' is the last hook called by wp-settings.php before 'init'.
-        // This is an attempt to run plugin activation somewhere after 'plugins_loaded' (which makes the disable-embeds plugin try to access $wp_rewrite before it's initialized)
-        // and before 'init' (since the polylang plugin needs to have it's activation being run after the 'init' hook (where it sets up it's default options)).
         add_action('after_setup_theme', function () use ($plugin) {
             foreach (array_keys($this->getPlugins()) as $plugin) {
-                // activate all plugins whether they've already been activated before
                 do_action('activate_'.$plugin);
             }
         });


### PR DESCRIPTION
Issue: some plugins introduced warnings/error when activated in the `wp_loaded` hook (`polylang` plugin uses the `init` hook which is run before `wp_loaded`).