### PR TITLE
Fix relative vs absolute url/path slashes & directory separators

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -117,7 +117,8 @@ if (!function_exists('stylesheet_path')) {
      */
     function stylesheet_path(string $path = ''): string
     {
-        $path = $path ? DIRECTORY_SEPARATOR.$path : $path;
+        $path = $path !== DIRECTORY_SEPARATOR ? ltrim($path, DIRECTORY_SEPARATOR) : $path;
+        $path = $path && $path !== DIRECTORY_SEPARATOR ? '/'.$path : $path;
 
         return sprintf('%s%s', get_stylesheet_directory(), $path);
     }
@@ -133,7 +134,10 @@ if (!function_exists('stylesheet_uri')) {
      */
     function stylesheet_uri(string $path = ''): string
     {
-        return sprintf('%s/%s', get_stylesheet_directory_uri(), ltrim($path, '/'));
+        $path = $path !== '/' ? ltrim($path, '/') : $path;
+        $path = $path && $path !== '/' ? '/'.$path : $path;
+
+        return sprintf('%s%s', get_stylesheet_directory_uri(), $path);
     }
 }
 
@@ -148,7 +152,8 @@ if (!function_exists('template_path')) {
      */
     function template_path(string $path = ''): string
     {
-        $path = $path ? DIRECTORY_SEPARATOR.$path : $path;
+        $path = $path !== DIRECTORY_SEPARATOR ? ltrim($path, DIRECTORY_SEPARATOR) : $path;
+        $path = $path && $path !== DIRECTORY_SEPARATOR ? '/'.$path : $path;
 
         return sprintf('%s%s', get_template_directory(), $path);
     }
@@ -165,6 +170,9 @@ if (!function_exists('template_uri')) {
      */
     function template_uri(string $path = ''): string
     {
-        return sprintf('%s/%s', get_template_directory_uri(), ltrim($path, '/'));
+        $path = $path !== '/' ? ltrim($path, '/') : $path;
+        $path = $path && $path !== '/' ? '/'.$path : $path;
+
+        return sprintf('%s%s', get_template_directory_uri(), $path);
     }
 }

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -100,22 +100,52 @@ class HelpersTest extends TestCase
 
     public function testStylesheetPath()
     {
+        $this->assertSame(__DIR__.'/stubs/child-theme', stylesheet_path());
+        $this->assertSame(__DIR__.'/stubs/child-theme/', stylesheet_path('/'));
+
+        $this->assertSame(__DIR__.'/stubs/child-theme/partials', stylesheet_path('partials'));
+        $this->assertSame(__DIR__.'/stubs/child-theme/partials', stylesheet_path('/partials'));
+        $this->assertSame(__DIR__.'/stubs/child-theme/partials/', stylesheet_path('/partials/'));
+
         $this->assertSame(__DIR__.'/stubs/child-theme/partials/navigation.php', stylesheet_path('partials/navigation.php'));
+        $this->assertSame(__DIR__.'/stubs/child-theme/partials/navigation.php', stylesheet_path('/partials/navigation.php'));
     }
 
     public function testStylesheetUri()
     {
+        $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme', stylesheet_uri());
+        $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/', stylesheet_uri('/'));
+
+        $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/assets', stylesheet_uri('assets'));
+        $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/assets', stylesheet_uri('/assets'));
+        $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/assets/', stylesheet_uri('/assets/'));
+
         $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/style.css', stylesheet_uri('style.css'));
         $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/style.css', stylesheet_uri('/style.css'));
     }
 
     public function testTemplatePath()
     {
+        $this->assertSame(__DIR__.'/stubs/parent-theme', template_path());
+        $this->assertSame(__DIR__.'/stubs/parent-theme/', template_path('/'));
+
+        $this->assertSame(__DIR__.'/stubs/parent-theme/partials', template_path('partials'));
+        $this->assertSame(__DIR__.'/stubs/parent-theme/partials', template_path('/partials'));
+        $this->assertSame(__DIR__.'/stubs/parent-theme/partials/', template_path('/partials/'));
+
         $this->assertSame(__DIR__.'/stubs/parent-theme/partials/navigation.php', template_path('partials/navigation.php'));
+        $this->assertSame(__DIR__.'/stubs/parent-theme/partials/navigation.php', template_path('/partials/navigation.php'));
     }
 
     public function testTemplateUri()
     {
+        $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme', template_uri());
+        $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme/', template_uri('/'));
+
+        $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme/assets', template_uri('assets'));
+        $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme/assets', template_uri('/assets'));
+        $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme/assets/', template_uri('/assets/'));
+
         $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme/style.css', template_uri('style.css'));
         $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme/style.css', template_uri('/style.css'));
     }


### PR DESCRIPTION
Fix `template_path`,`template_uri`, `stylesheet_path` & `stylesheet_uri` slashes & directory separators behavior.

Example:
`template_path()` should return `/stubs/child-theme`
`template_path('/')` should return `/stubs/child-theme/`
`template_path('assets')` should return `/stubs/child-theme/assets`
`template_path('/assets')` should return `/stubs/child-theme/assets`
`template_path('/assets/')` should return `/stubs/child-theme/assets/`
