### PR TITLE
Add relative path to mu-plugins

### DIFF
--- a/src/PluginLoader.php
+++ b/src/PluginLoader.php
@@ -123,11 +123,18 @@ final class PluginLoader
             return $plugins;
         }
 
-        if (empty($plugins)) {
-            return array_keys($this->getPlugins());
+        foreach (array_keys($this->getPlugins()) as $plugin) {
+            $plugins = array_diff($plugins, [$plugin]);
+            if ($this->isPluginActive($plugin)) {
+                // Remove plugin from array, if exists
+                $plugins = array_diff($plugins, [$plugin]);
+
+                // Add plugin with relative url to WPMU_PLUGIN_DIR
+                $plugins[] = $this->getRelativePath().$plugin;
+            }
         }
 
-        return array_unique(array_merge($plugins, array_keys($this->getPlugins())));
+        return array_unique($plugins);
     }
 
     /**
@@ -173,7 +180,7 @@ final class PluginLoader
         require_once ABSPATH.'wp-admin/includes/plugin.php';
 
         $plugins = array_diff_key(
-            get_plugins($this->getRelativePath()),
+            get_plugins('/'.$this->getRelativePath()),
             get_mu_plugins()
         );
 
@@ -273,7 +280,7 @@ final class PluginLoader
             WPMU_PLUGIN_DIR.'/'
         );
 
-        return '/'.$relativePath;
+        return $relativePath;
     }
 
     /**


### PR DESCRIPTION
This makes `get_option( 'active_plugins', ...` work for plugins using `get_plugin_data(WP_PLUGIN_DIR.'/' .$plugin)` work.
Example of plugin: Woocommerce Admin Status Page (https://github.com/woocommerce/woocommerce/blob/master/includes/api/class-wc-rest-system-status-controller.php#L783)