### PR TITLE
Set base path as default path

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -41,17 +41,17 @@ final class Application extends Container
     /**
      * Create a new application instance.
      *
-     * @param string $publicPath
+     * @param string $basePath
      *
      * @return void
      */
-    public function __construct(string $publicPath)
+    public function __construct(string $basePath)
     {
-        $this->publicPath = $publicPath;
+        $this->basePath = $basePath;
         $this->pluginLoader = new PluginLoader();
 
         try {
-            (new Dotenv($this->getBasePath()))->load();
+            (new Dotenv($this->basePath))->load();
         } catch (InvalidPathException $e) {
             //
         }
@@ -140,23 +140,7 @@ final class Application extends Container
      */
     public function getBasePath(): string
     {
-        if (is_null($this->basePath)) {
-            return realpath($this->publicPath.'/../');
-        }
-
         return $this->basePath;
-    }
-
-    /**
-     * Get the base path for the application.
-     *
-     * @param string $basePath
-     *
-     * @return void
-     */
-    public function setBasePath(string $basePath)
-    {
-        $this->basePath = $basePath;
     }
 
     /**
@@ -166,6 +150,10 @@ final class Application extends Container
      */
     public function getPublicPath(): string
     {
+        if (is_null($this->publicPath)) {
+            return $this->basePath.DIRECTORY_SEPARATOR.'public';
+        }
+
         return $this->publicPath;
     }
 

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -25,7 +25,7 @@ class ApplicationTest extends TestCase
 {
     public function testInvalidPathException()
     {
-        $application = new Application(__DIR__.'/stubs/public');
+        $application = new Application(__DIR__.'/stubs');
 
         putenv('WP_DIR=wordpress');
 
@@ -42,13 +42,10 @@ class ApplicationTest extends TestCase
     {
         file_put_contents(__DIR__.'/stubs/.env', 'WP_DIR=wordpress');
 
-        $application = new Application(__DIR__.'/stubs/public');
+        $application = new Application(__DIR__.'/stubs');
         $application->run();
 
         $this->assertInstanceOf(Application::class, $application);
-
-        $application->setBasePath(__DIR__);
-        $this->assertSame(__DIR__, $application->getBasePath());
 
         $application->setPublicPath(__DIR__);
         $this->assertSame(__DIR__, $application->getPublicPath());

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -33,7 +33,7 @@ class HelpersTest extends TestCase
 
     public function testBasePath()
     {
-        new Application(__DIR__.'/stubs');
+        new Application(__DIR__);
 
         $this->assertSame(__DIR__, base_path());
         $this->assertSame(__DIR__.'/88mph.php', base_path('88mph.php'));


### PR DESCRIPTION
This will change the default path to `$basePath` instead of `$publicPath`. Since we want to load the environment variables first it makes more sense to go back to the previous behaviour. This way users can still move everything out of the `public` directory into the root directory by using the `setPublicPath` method in their `wp-config.php` config file.

This update has also needs to be update in `wordplate/wordplate`:

https://github.com/wordplate/wordplate/blob/73e9bec46901376f1dae12fdf44f56c1d37b1d18/public/wp-config.php#L39-L41

This should be added in version 7.0 since it is a breaking change.