### PR TITLE
Move plugin loader instance creation

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -48,7 +48,6 @@ final class Application extends Container
     public function __construct(string $publicPath)
     {
         $this->publicPath = $publicPath;
-        $this->pluginLoader = new PluginLoader();
 
         try {
             (new Dotenv($this->getBasePath()))->load();
@@ -130,7 +129,8 @@ final class Application extends Container
         }
 
         // Load the must-use plugins.
-        $this->pluginLoader->load();
+        $pluginLoader = new PluginLoader();
+        $pluginLoader->load();
     }
 
     /**


### PR DESCRIPTION
The `$pluginLoader` does not need to be added as a property on the application instance. This pull request simply moves it to the `run` method. 

Since this was available on the application instance as a public property (visibility not specified) we should regard this as a breaking change and merge it in version 7.0.