### PR TITLE
Update WordPress to 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-mbstring": "*",
         "composer/installers": "^1.6",
         "illuminate/support": "^5.7",
-        "johnpbloch/wordpress": "^4.9.8",
+        "johnpbloch/wordpress": "^5.0",
         "roots/wp-password-bcrypt": "^1.0",
         "symfony/http-foundation": "^4.1",
         "symfony/routing": "^4.2",


### PR DESCRIPTION
WordPress 5.0 is just around the corner and this pull request will add support for the new version.

- [A Plan for 5.0](https://make.wordpress.org/core/2018/10/03/a-plan-for-5-0/) - Matt Mullenweg

This pull request will be on hold until WordPress 5.0 is released.