### PR TITLE
Add template_slug helper function

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -159,6 +159,27 @@ if (!function_exists('template_path')) {
     }
 }
 
+if (!function_exists('template_slug')) {
+    /**
+     * Get page template slug.
+     *
+     * @param int|\WP_Post|null $post
+     *
+     * @return string|null
+     */
+    function template_slug($post = null): ?string
+    {
+        if (!$post) {
+            return null;
+        }
+
+        $slug = get_page_template_slug($post);
+        $filename = pathinfo($slug)['filename'];
+
+        return $filename !== '' ? $filename : null;
+    }
+}
+
 if (!function_exists('template_url')) {
     /**
      * Generate a uri for the current theme directory or to the parent theme

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -137,6 +137,12 @@ class HelpersTest extends TestCase
         $this->assertSame(__DIR__.'/stubs/parent-theme/partials/navigation.php', template_path('/partials/navigation.php'));
     }
 
+    public function testTemplateSlug()
+    {
+        $this->assertNull(template_slug());
+        $this->assertSame('about', template_slug(1));
+    }
+
     public function testTemplateUrl()
     {
         $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme', template_url());

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -56,6 +56,11 @@ function get_template_directory_uri()
     return 'https://wordplate.dev/wp-content/themes/parent-theme';
 }
 
+function get_page_template_slug($page = null)
+{
+    return $page ? 'page-templates/about.php' : null;
+}
+
 function is_blog_installed()
 {
     return true;


### PR DESCRIPTION
This pull request adds a helper function to get a page's slug. The `get_page_template_slug` function returns the fullpath to a page template:

```php
echo get_page_template_slug($post); // page-templates/about.php
```

This pull requests adds the `template_slug` function to only get the template file name:

```php
echo template_slug($post); // about
```

Some questions to answer: will this be useful? Are you using something similar?