### PR TITLE
Add a way to disable PluginLoader

### DIFF
--- a/src/PluginLoader.php
+++ b/src/PluginLoader.php
@@ -47,6 +47,10 @@ final class PluginLoader
      */
     public function load(): void
     {
+        if (defined('DISABLE_PLUGIN_LOADER') && DISABLE_PLUGIN_LOADER) {
+            return;
+        }
+
         // Load WordPress's action and filter helper functions.
         require_once ABSPATH.'wp-includes/plugin.php';
 


### PR DESCRIPTION
When enable Network/Multisite, Wordpress want's you to disable all plugins, this is a shortcut to disable all plugins without renaming you mu-plugin dir or running `composer remove` on all your plugins.