### PR TITLE
Remove WP_ENV constant

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,7 +25,4 @@
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>
-    <php>
-        <env name="WP_ENV" value="testing"/>
-    </php>
 </phpunit>

--- a/src/Application.php
+++ b/src/Application.php
@@ -65,9 +65,6 @@ final class Application extends Container
      */
     public function run()
     {
-        // The WordPress environment.
-        define('WP_ENV', env('WP_ENV', 'production'));
-
         // For developers: WordPress debugging mode.
         $debug = env('WP_DEBUG', false);
         define('WP_DEBUG', $debug);


### PR DESCRIPTION
Removed the environment variable `WP_ENV` since it isn't used anywhere. It basically just takes up space. 

This has also been updated in `wordplate/wordplate`: https://github.com/wordplate/wordplate/commit/3fad536fdd1781adb781493daef15a08bd61cb40