### PR TITLE
Remove asset, stylesheet_url and template_url functions

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -14,20 +14,6 @@ declare(strict_types=1);
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 
-if (!function_exists('asset')) {
-    /**
-     * Generate a url for the current theme directory.
-     *
-     * @param string $path
-     *
-     * @return string
-     */
-    function asset(string $path = ''): string
-    {
-        return stylesheet_url($path);
-    }
-}
-
 if (!function_exists('mix')) {
     /**
      * Get the path to a versioned Mix file.
@@ -63,41 +49,6 @@ if (!function_exists('mix')) {
             throw new Exception("Unable to locate Mix file: {$path}. Please check your webpack.mix.js output paths and try again.");
         }
 
-        return new HtmlString(asset($manifestDirectory.$manifest[$path]));
-    }
-}
-
-if (!function_exists('stylesheet_url')) {
-    /**
-     * Generate a uri for the current/child theme directory.
-     *
-     * @param string $path
-     *
-     * @return string
-     */
-    function stylesheet_url(string $path = ''): string
-    {
-        $path = $path !== '/' ? ltrim($path, '/') : $path;
-        $path = $path && $path !== '/' ? '/'.$path : $path;
-
-        return sprintf('%s%s', get_stylesheet_directory_uri(), $path);
-    }
-}
-
-if (!function_exists('template_url')) {
-    /**
-     * Generate a uri for the current theme directory or to the parent theme
-     * if a child theme is being used.
-     *
-     * @param string $path
-     *
-     * @return string
-     */
-    function template_url(string $path = ''): string
-    {
-        $path = $path !== '/' ? ltrim($path, '/') : $path;
-        $path = $path && $path !== '/' ? '/'.$path : $path;
-
-        return sprintf('%s%s', get_template_directory_uri(), $path);
+        return new HtmlString(get_theme_file_uri($manifestDirectory.$manifest[$path]));
     }
 }

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -24,12 +24,6 @@ use PHPUnit\Framework\TestCase;
  */
 class HelpersTest extends TestCase
 {
-    public function testAsset()
-    {
-        $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/style.css', stylesheet_url('style.css'));
-        $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/style.css', stylesheet_url('/style.css'));
-    }
-
     /**
      * @runInSeparateProcess
      */
@@ -76,31 +70,5 @@ class HelpersTest extends TestCase
         $this->expectExceptionMessage('The Mix manifest does not exist.');
 
         mix('1985.js');
-    }
-
-    public function testStylesheetUrl()
-    {
-        $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme', stylesheet_url());
-        $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/', stylesheet_url('/'));
-
-        $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/assets', stylesheet_url('assets'));
-        $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/assets', stylesheet_url('/assets'));
-        $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/assets/', stylesheet_url('/assets/'));
-
-        $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/style.css', stylesheet_url('style.css'));
-        $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/style.css', stylesheet_url('/style.css'));
-    }
-
-    public function testTemplateUrl()
-    {
-        $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme', template_url());
-        $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme/', template_url('/'));
-
-        $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme/assets', template_url('assets'));
-        $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme/assets', template_url('/assets'));
-        $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme/assets/', template_url('/assets/'));
-
-        $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme/style.css', template_url('style.css'));
-        $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme/style.css', template_url('/style.css'));
     }
 }

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -41,6 +41,11 @@ function get_stylesheet_directory()
     return __DIR__.'/stubs/child-theme';
 }
 
+function get_theme_file_uri(string $path)
+{
+    return 'https://wordplate.dev/wp-content/themes/child-theme'.$path;
+}
+
 function get_stylesheet_directory_uri()
 {
     return 'https://wordplate.dev/wp-content/themes/child-theme';


### PR DESCRIPTION
This is a follow up pull request to #78 where we discuss if we can rely on WordPress functions instead of rolling our own. The `asset`, `stylesheet_url` and `template_url` functions can be replaced by WordPress [`get_theme_file_uri`](https://developer.wordpress.org/reference/functions/get_theme_file_uri/) function.

**Benefits:**

- Encourage users to use WordPress functions.
- WordPlate will leave a smaller footprint.
- Less helpers functions to maintain.
- Makes it easier to use theme's outside WordPlate.