### PR TITLE
Remove PHP 7.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "ext-mbstring": "*",
         "composer/installers": "^1.6",
         "illuminate/support": "5.8.*",
@@ -34,7 +34,7 @@
         "vlucas/phpdotenv": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5 || ^8.1"
+        "phpunit/phpunit": "^8.1"
     },
     "config": {
         "preferred-install": "dist"

--- a/src/Application.php
+++ b/src/Application.php
@@ -58,7 +58,7 @@ final class Application extends Container
      *
      * @return void
      */
-    public function run()
+    public function run(): void
     {
         // For developers: WordPress debugging mode.
         $debug = env('WP_DEBUG', false);


### PR DESCRIPTION
This pull request remove PHP 7.1 support. Version 7.1 will reach end of life this year and is currently only receiving security fixes. Version 7.4 will be released later this year. Since we're working on a new major release we should take the opportunity to remove PHP version support if possible. Laravel and Symfony will jump to `7.2` this year as well.

![image](https://user-images.githubusercontent.com/499192/57579826-de524100-74a1-11e9-9f66-d7aeee3b8806.png)

**Benefits:**

- Fewer PHP versions to maintain.
- Being able to use PHP 7.2 features.
- Drop support for older PHPUnit versions.
- Pushing the web forward.

**Drawbacks:**

- Users of older versions need to upgrade their PHP version.
  _This isn't much of a drawback since WordPlate 7 and 8 will work similarly. Users can simply stay on version 7 until they upgrade PHP._

cc @wordplate/developers 
