### PR TITLE
Remove template_slug function

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -142,27 +142,6 @@ if (!function_exists('template_path')) {
     }
 }
 
-if (!function_exists('template_slug')) {
-    /**
-     * Get page template slug.
-     *
-     * @param int|\WP_Post|null $post
-     *
-     * @return string|null
-     */
-    function template_slug($post = null): ?string
-    {
-        if (!$post) {
-            return null;
-        }
-
-        $slug = get_page_template_slug($post);
-        $filename = pathinfo($slug)['filename'];
-
-        return $filename !== '' ? $filename : null;
-    }
-}
-
 if (!function_exists('template_url')) {
     /**
      * Generate a uri for the current theme directory or to the parent theme

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -130,12 +130,6 @@ class HelpersTest extends TestCase
         $this->assertSame(__DIR__.'/stubs/parent-theme/partials/navigation.php', template_path('/partials/navigation.php'));
     }
 
-    public function testTemplateSlug()
-    {
-        $this->assertNull(template_slug());
-        $this->assertSame('about', template_slug(1));
-    }
-
     public function testTemplateUrl()
     {
         $this->assertSame('https://wordplate.dev/wp-content/themes/parent-theme', template_url());

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -51,11 +51,6 @@ function get_template_directory_uri()
     return 'https://wordplate.dev/wp-content/themes/parent-theme';
 }
 
-function get_page_template_slug($page = null)
-{
-    return $page ? 'page-templates/about.php' : null;
-}
-
 function is_blog_installed()
 {
     return true;


### PR DESCRIPTION
This pull request removes the `template_slug` function. This function shouldn't have been added in the first place. This is on me. Sorry!