### PR TITLE
Remove hot reloading support

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -70,10 +70,6 @@ if (!function_exists('mix')) {
             $manifestDirectory = "/{$manifestDirectory}";
         }
 
-        if (file_exists(stylesheet_path($manifestDirectory.'/hot'))) {
-            return new HtmlString("//localhost:8080{$path}");
-        }
-
         if (!$manifest) {
             if (!file_exists($manifestPath = stylesheet_path($manifestDirectory.'/mix-manifest.json'))) {
                 throw new Exception('The Mix manifest does not exist.');

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -51,11 +51,7 @@ class HelpersTest extends TestCase
         $this->assertInstanceOf(HtmlString::class, mix('1955.js'));
         $this->assertSame('https://wordplate.dev/wp-content/themes/child-theme/assets/1955.js?id=740b8162ec', (string) mix('1955.js'));
 
-        mkdir(__DIR__.'/stubs/child-theme/assets/hot');
-        $this->assertSame('//localhost:8080/1955.js', (string) mix('1955.js'));
-
         unlink(__DIR__.'/stubs/child-theme/assets/mix-manifest.json');
-        rmdir(__DIR__.'/stubs/child-theme/assets/hot');
         rmdir(__DIR__.'/stubs/child-theme/assets');
         rmdir(__DIR__.'/stubs/child-theme');
     }


### PR DESCRIPTION
This pull request removes hot reloading support from the `mix` function. We [update the default npm scripts](https://github.com/wordplate/wordplate/commit/56247d3077a6c1ec83cefa21baea331bdeab737d#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) last year and we no longer have the `hot` script listed in our `package.json` file.