### PR TITLE
Added ability to customize the .env file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Added ability to customize `.env` path via `Application::setEnvironmentFilePath` method
+
 ## 7.1.0 (released 2019-02-27)
 
 - Added laravel/helpers package

--- a/src/Application.php
+++ b/src/Application.php
@@ -38,6 +38,13 @@ final class Application
     protected $publicPath;
 
     /**
+     * The environment file path.
+     *
+     * @var string
+     */
+    protected $environmentFilePath;
+
+    /**
      * Create a new application instance.
      *
      * @param string $basePath
@@ -47,8 +54,6 @@ final class Application
     public function __construct(string $basePath)
     {
         $this->basePath = $basePath;
-
-        Dotenv::create($this->basePath)->safeLoad();
     }
 
     /**
@@ -58,6 +63,9 @@ final class Application
      */
     public function run(): void
     {
+        // Boot the environment
+        Dotenv::create($this->getEnvironmentFilePath())->safeLoad();
+
         // For developers: WordPress debugging mode.
         $debug = env('WP_DEBUG', false);
         define('WP_DEBUG', $debug);
@@ -157,5 +165,25 @@ final class Application
     public function setPublicPath(string $publicPath)
     {
         $this->publicPath = $publicPath;
+    }
+
+    /**
+     * Get the environment file path.
+     *
+     * @return string
+     */
+    public function getEnvironmentFilePath(): string
+    {
+        return $this->environmentFilePath ?: $this->getBasePath();
+    }
+
+    /**
+     * Set the environment file path.
+     *
+     * @param string $environmentFilePath
+     */
+    public function setEnvironmentFilePath(string $environmentFilePath)
+    {
+        $this->environmentFilePath = $environmentFilePath;
     }
 }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -51,7 +51,27 @@ class ApplicationTest extends TestCase
 
         $application->setPublicPath(__DIR__);
         $this->assertSame(__DIR__, $application->getPublicPath());
+        $this->assertSame($application->getBasePath(), $application->getEnvironmentFilePath());
 
         unlink(__DIR__.'/stubs/.env');
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testCustomEnvirnomentFilePath()
+    {
+        $environmentFilePath = sys_get_temp_dir().'/.env';
+        file_put_contents($environmentFilePath, 'WP_DIR=wordpress');
+
+        $application = new Application(__DIR__.'/stubs');
+        $application->setEnvironmentFilePath($environmentFilePath);
+        $application->run();
+
+        $this->assertInstanceOf(Application::class, $application);
+        $this->assertSame($environmentFilePath, $application->getEnvironmentFilePath());
+
+        unlink($environmentFilePath);
     }
 }


### PR DESCRIPTION
This pull request adds the ability to customize the .env file path. In some environments, it can be useful to allow that if the .env file is located in a vault directory.

This pull requests test the env variable ENV_PATH or fall back on the default $basePath variable.