### PR TITLE
Make the application class non-final

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Vincent Klaiber <hello@doubledip.se>
  */
-final class Application
+class Application
 {
     /**
      * The base path for the WordPlate installation.


### PR DESCRIPTION
As discussed in #87 we should make the application class non-final giving users of WordPlate the option to extend the framework. This shouldn't be a problem since we follow semantic versioning.

Closes #87 