### PR TITLE
Remove ext-mbstring dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     ],
     "require": {
         "php": "^7.2",
-        "ext-mbstring": "*",
         "composer/installers": "^1.6",
         "johnpbloch/wordpress": "^5.2",
         "roots/wp-password-bcrypt": "^1.0",


### PR DESCRIPTION
Since we dropped the string and array helper functions we no longer need to include the mbstring PHP extension as a dependency requirement.