### PR TITLE
Register WP_CACHE constant

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -121,6 +121,9 @@ class Application
         // Disable technical issues emails.
         // https://make.wordpress.org/core/2019/04/16/fatal-error-recovery-mode-in-5-2/
         define('WP_DISABLE_FATAL_ERROR_HANDLER', env('WP_DISABLE_FATAL_ERROR_HANDLER', false));
+        
+        // Set the WordPress cache constant
+        define('WP_CACHE', env('WP_CACHE', true));
 
         // Set the absolute path to the WordPress directory.
         if (!defined('ABSPATH')) {

--- a/src/Application.php
+++ b/src/Application.php
@@ -121,8 +121,8 @@ class Application
         // Disable technical issues emails.
         // https://make.wordpress.org/core/2019/04/16/fatal-error-recovery-mode-in-5-2/
         define('WP_DISABLE_FATAL_ERROR_HANDLER', env('WP_DISABLE_FATAL_ERROR_HANDLER', false));
-        
-        // Set the WordPress cache constant
+
+        // Set the cache constant for plugins such as WP Super Cache and W3 Total Cache.
         define('WP_CACHE', env('WP_CACHE', true));
 
         // Set the absolute path to the WordPress directory.


### PR DESCRIPTION
## Proposed Changes
  - Set the WP_CACHE constant and set default value to true (otherwise plugins may destroy the wp-config.php file by pasting the constant at the beginning of the file)