### PR TITLE
Replace symfony/dotenv with vlucas/phpdotenv

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
         "johnpbloch/wordpress-core": "^5.4",
         "roots/bedrock-autoloader": "^1.0",
         "roots/wp-password-bcrypt": "^1.0",
-        "symfony/dotenv": "^5.0",
         "symfony/http-foundation": "^5.0",
         "symfony/routing": "^5.0",
-        "symfony/var-dumper": "^5.0"
+        "symfony/var-dumper": "^5.0",
+        "vlucas/phpdotenv": "^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || 9.1",

--- a/src/Application.php
+++ b/src/Application.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace WordPlate;
 
+use Dotenv\Dotenv;
+use Dotenv\Exception\InvalidPathException;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Dotenv\Dotenv;
-use Symfony\Component\Dotenv\Exception\PathException;
 
 class Application
 {
@@ -30,9 +30,9 @@ class Application
         $this->basePath = $basePath;
 
         try {
-            $environment = new Dotenv();
-            $environment->load($this->basePath . '/.env');
-        } catch (PathException $exception) {
+            $dotenv = Dotenv::createImmutable($this->basePath);
+            $dotenv->load();
+        } catch (InvalidPathException $exception) {
             //
         }
     }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace WordPlate\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Dotenv\Dotenv;
 use WordPlate\Application;
 
 class ApplicationTest extends TestCase
@@ -65,10 +64,8 @@ class ApplicationTest extends TestCase
             ['DOTENV_STRING', 'einstein', 'einstein'],
         ];
 
-        $environment = new Dotenv();
-
         foreach ($variables as [$key, $value, $expected]) {
-            $environment->populate([$key => $value]);
+            $_ENV[$key] = $value;
             $this->assertSame($expected, env($key));
         }
     }


### PR DESCRIPTION
This pull request switches back to vlucas/phpdotenv instead of symfony/dotenv. 

@fiskhandlarn this should fix the issues https://github.com/wordplate/wordplate/issues/254 and https://github.com/wordplate/wordplate/issues/250, right?