### PR TITLE
Update Application.php default env for DB_HOST

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -51,7 +51,7 @@ class Application
         define('DB_NAME', env('DB_NAME'));
         define('DB_USER', env('DB_USER'));
         define('DB_PASSWORD', env('DB_PASSWORD'));
-        define('DB_HOST', env('DB_HOST'));
+        define('DB_HOST', env('DB_HOST', '127.0.0.1'));
         define('DB_CHARSET', env('DB_CHARSET', 'utf8mb4'));
         define('DB_COLLATE', env('DB_COLLATE', 'utf8mb4_unicode_ci'));
 


### PR DESCRIPTION
In most cases, the DB Host is localhost or 127.0.0.1, and I think you can easily forget that you need to set the DB_HOST variable if you running localhost and expect this to be a default value.