### PR TITLE
Added php 8.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.3, 7.4]
+        php: [7.3, 7.4, 8.0]
 
     name: PHP ${{ matrix.php }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Added PHP 8.0 support
+
 ## 9.2.0
 
 - Updated to laravel-mix 6.0

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "composer/installers": "^1.9",
         "johnpbloch/wordpress-core-installer": "^2.0",
@@ -40,7 +40,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "9.2-dev"
+            "dev-master": "9.3-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
This pull request adds support for PHP 8.0. WordPress plans on adding support on December 8.