### PR TITLE
Remove notices for CLI 

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -17,13 +17,13 @@ class Request
 {
     public static function isSecure(): bool
     {
-        return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443;
+        return !isset($_SERVER['HTTPS']) && (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443;
     }
 
     public static function getSchemeAndHttpHost(): string
     {
         $protocol = static::isSecure() ? 'https' : 'http';
 
-        return $protocol . '://' . $_SERVER['HTTP_HOST'];
+        return $protocol . '://' . (isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '');
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -24,6 +24,6 @@ class Request
     {
         $protocol = static::isSecure() ? 'https' : 'http';
 
-        return $protocol . '://' . (isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '');
+        return $protocol . '://' . (isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : 'localhost');
     }
 }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -40,7 +40,7 @@ class ApplicationTest extends TestCase
         $application = new Application(__DIR__);
         $application->run();
 
-        $this->assertSame(__DIR__ . '/public', $application->getPublicPath());
+        $this->assertSame(__DIR__ . DIRECTORY_SEPARATOR . 'public', $application->getPublicPath());
 
         $application->setPublicPath(__DIR__);
         $this->assertSame(__DIR__, $application->getPublicPath());


### PR DESCRIPTION
Fixes this:
```bash
$ wp
PHP Notice: Undefined index: SERVER_PORT in vendor/wordplate/framework/src/Request.php on line 20
PHP Notice: Undefined index: HTTP_HOST in vendor/wordplate/framework/src/Request.php on line 27
```

Bonus: Fix testPublicPath for Windows