### PR TITLE
Remove WP_URL env variable

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -73,7 +73,7 @@ class Application
         define('NONCE_SALT', env('NONCE_SALT'));
 
         // Set the home url to the current domain.
-        define('WP_HOME', env('WP_HOME', env('WP_URL', Request::getSchemeAndHttpHost()))); // TODO: Remove WP_URL in the next major version
+        define('WP_HOME', env('WP_HOME', Request::getSchemeAndHttpHost()));
 
         // Set the WordPress directory path.
         define('WP_SITEURL', env('WP_SITEURL', sprintf('%s/%s', WP_HOME, env('WP_DIR', 'wordpress'))));


### PR DESCRIPTION
This pull request removes the `WP_URL` constant in favour of the default `WP_HOME` constant.