### PR TITLE
Remove WP_THEME env variable

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -86,7 +86,7 @@ class Application
         define('EMPTY_TRASH_DAYS', env('EMPTY_TRASH_DAYS', 7));
 
         // Set the default WordPress theme.
-        define('WP_DEFAULT_THEME', env('WP_DEFAULT_THEME', env('WP_THEME', 'wordplate'))); // TODO: Remove WP_THEME in the next major version
+        define('WP_DEFAULT_THEME', env('WP_DEFAULT_THEME', 'wordplate'));
 
         // Constant to configure core updates.
         define('WP_AUTO_UPDATE_CORE', env('WP_AUTO_UPDATE_CORE', 'minor'));


### PR DESCRIPTION
This pull request removes the `WP_THEME` constant in favour of the default `WP_DEFAULT_THEME` constant.