### PR TITLE
Rename WP_ENV to WP_ENVIRONMENT_TYPE

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -39,7 +39,7 @@ class Application
     public function run(): void
     {
         // Set the environment type.
-        define('WP_ENVIRONMENT_TYPE', env('WP_ENV', 'production'));
+        define('WP_ENVIRONMENT_TYPE', env('WP_ENVIRONMENT_TYPE', 'production'));
 
         // For developers: WordPress debugging mode.
         $debug = env('WP_DEBUG', false);


### PR DESCRIPTION
This pull request will update the `WP_ENV` variabel to the default `WP_ENVIRONMENT_TYPE` constant.

Depends on https://github.com/wordplate/wordplate/pull/272